### PR TITLE
update the import context state on update

### DIFF
--- a/importer/src/main/java/org/opengeo/data/importer/ImportContext.java
+++ b/importer/src/main/java/org/opengeo/data/importer/ImportContext.java
@@ -176,7 +176,7 @@ public class ImportContext implements Serializable {
         return null;
     }
 
-    public void updateState() {
+    private void updateState() {
         State newState = State.COMPLETE;
      O: for (ImportTask task : tasks) {
             switch(task.getState()) {
@@ -196,6 +196,7 @@ public class ImportContext implements Serializable {
 
     public void updated() {
         updated = new Date();
+        updateState();
     }
 
     public void delete() throws IOException {

--- a/importer/src/main/java/org/opengeo/data/importer/Importer.java
+++ b/importer/src/main/java/org/opengeo/data/importer/Importer.java
@@ -574,7 +574,6 @@ public class Importer implements InitializingBean, DisposableBean {
             run(task, filter);
         }
 
-        context.updateState();
         context.updated();
         contextStore.save(context);
     }

--- a/importer/src/test/java/org/opengeo/data/importer/ImportContextTest.java
+++ b/importer/src/test/java/org/opengeo/data/importer/ImportContextTest.java
@@ -17,21 +17,21 @@ public class ImportContextTest extends TestCase {
         assertEquals(ImportContext.State.PENDING, context.getState());
 
         t1.setState(ImportTask.State.READY);
-        context.updateState();
+        context.updated();
         assertEquals(ImportContext.State.INCOMPLETE, context.getState());
         
         t2.setState(ImportTask.State.READY);
         t3.setState(ImportTask.State.READY);
-        context.updateState();
+        context.updated();
         assertEquals(ImportContext.State.READY, context.getState());
 
         t1.setState(ImportTask.State.COMPLETE);
         t2.setState(ImportTask.State.COMPLETE);
-        context.updateState();
+        context.updated();
         assertEquals(ImportContext.State.READY, context.getState());
         
         t3.setState(ImportTask.State.COMPLETE);
-        context.updateState();
+        context.updated();
         assertEquals(ImportContext.State.COMPLETE, context.getState());
     }
 }

--- a/importer/src/test/java/org/opengeo/data/importer/rest/ItemResourceTest.java
+++ b/importer/src/test/java/org/opengeo/data/importer/rest/ItemResourceTest.java
@@ -8,6 +8,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import org.opengeo.data.importer.Directory;
+import org.opengeo.data.importer.ImportContext.State;
 import org.opengeo.data.importer.Importer;
 import org.opengeo.data.importer.ImporterTestSupport;
 import org.opengeo.data.importer.SpatialFile;
@@ -98,6 +99,8 @@ public class ItemResourceTest extends ImporterTestSupport {
         assertEquals("READY", item.get("state"));
         assertEquals("EPSG:26713", 
             item.getJSONObject("resource").getJSONObject("featureType").getString("srs"));
+        State state = context.getState();
+        assertEquals("Invalid context state", State.READY, state);
     }
 
     public void testDeleteItem() throws Exception {


### PR DESCRIPTION
Previously, if updateState was not called explicitly, then the state on
the context itself never got updated. When determining the state during
the prep call, the task would get updated but that never got propagated
back up to the context.
