### PR TITLE
Explicilty disabled JAI's native media lib for unit tests in import/core

### DIFF
--- a/importer/core/pom.xml
+++ b/importer/core/pom.xml
@@ -84,6 +84,16 @@
         </execution>
     </executions>
    </plugin>
+   <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-surefire-plugin</artifactId>
+       <version>2.15</version>
+       <configuration>
+           <systemPropertyVariables>
+               <com.sun.media.jai.disableMediaLib>true</com.sun.media.jai.disableMediaLib>
+           </systemPropertyVariables>
+       </configuration>
+   </plugin>
    </plugins>
   </build>
 


### PR DESCRIPTION
Explicitly disable use of JAI's native media library even if it's present.
- Pros
  - The JAI media lib implementation distributed with OS X has an issue causing the unit test to fail, this is resolved
    - _The JAI in OS X is embedded in the JRE and overrides the version specified in maven_
  - Will allow for consistent unit test results across all platforms using the same version of JAI
  - Will avoid informational exception stack trace with error loading mlib classes during unit tests (no broken windows!)
- Cons
  - Won't test use of JAI media lib if present

Notes
- Plugin version specification could be pushed up to a parent and specified using plugin management section for consistent plugin versioning across all children.
