### PR TITLE
don't show the "Activity" and "Reports" pages

### DIFF
--- a/mapmeter/src/main/java/org/geoserver/monitor/GeoServerMonitorFilter.java
+++ b/mapmeter/src/main/java/org/geoserver/monitor/GeoServerMonitorFilter.java
@@ -1,0 +1,13 @@
+package org.geoserver.monitor;
+
+import org.geoserver.platform.ExtensionFilter;
+
+public class GeoServerMonitorFilter implements ExtensionFilter {
+
+    @Override
+    public boolean exclude(String beanId, Object bean) {
+        // don't show the "Activity" and "Reports" pages in the "Monitor" category
+        return "monitorActivityPage".equals(beanId) || "monitorReportPage".equals(beanId);
+    }
+
+}

--- a/mapmeter/src/main/resources/applicationContext.xml
+++ b/mapmeter/src/main/resources/applicationContext.xml
@@ -12,6 +12,9 @@
         <constructor-arg ref="resourceLoader" index="0" />
     </bean>
 
+    <!-- don't show the "Activity" and "Reports" pages in the "Monitor" category -->
+    <bean id="gsMonitorFilter" class="org.geoserver.monitor.GeoServerMonitorFilter" />
+
     <bean id="mapmeterTransporterPostProcessor" class="org.geoserver.monitor.MessageTransportPostProcessor">
       <constructor-arg ref="mapmeterMonitorTransport" index="0"/>
       <constructor-arg ref="mapmeterRequestDataFactory" index="1"/>


### PR DESCRIPTION
In the Geoserver admin, don't show the activity and reports pages in the
monitor section. Mapmeter is the only link that shows up there now.
