### PR TITLE
fixed build issue by removing assembly plugin from individual ext pom files

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -102,24 +102,6 @@
     
   </dependencies>
 
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-  
   <properties>
     <hazelcast.version>2.3.1</hazelcast.version>
   </properties>

--- a/gsr/pom.xml
+++ b/gsr/pom.xml
@@ -157,25 +157,6 @@
           </excludes>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.3</version>
-        <configuration>
-          <descriptors>
-            <descriptor>assembly.xml</descriptor>
-          </descriptors>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
 
     <testResources>

--- a/mapmeter/pom.xml
+++ b/mapmeter/pom.xml
@@ -66,20 +66,6 @@
         </includes>
       </testResource>
     </testResources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
since moved asm plugin files by commit e286cac0e244ec22453435ee4c3722d619742ad0 caused an issue, and root pom now handles asm for all the exts, just needed to removing the plugin from individual ext poms.  
