### PR TITLE
Config lock support in clustering extension

### DIFF
--- a/cluster/src/main/java/org/geoserver/cluster/hazelcast/HzCluster.java
+++ b/cluster/src/main/java/org/geoserver/cluster/hazelcast/HzCluster.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Logger;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.cluster.ClusterConfig;
 import org.geoserver.cluster.ClusterConfigWatcher;
 import org.geoserver.config.GeoServerDataDirectory;
@@ -35,6 +36,7 @@ public class HzCluster implements DisposableBean, InitializingBean {
     HazelcastInstance hz;
     GeoServerResourceLoader rl;
     ClusterConfigWatcher watcher;
+    GeoServerConfigurationLock configurationLock;
 
     /**
      * Get a file from the cluster config directory. Create it by copying a template from the
@@ -137,5 +139,19 @@ public class HzCluster implements DisposableBean, InitializingBean {
     
     ClusterConfig getClusterConfig() {
         return watcher.get();
+    }
+
+    /**
+     * @param configurationLock the configurationLock to set
+     */
+    public void setConfigurationLock(GeoServerConfigurationLock configurationLock) {
+        this.configurationLock = configurationLock;
+    }
+
+    /**
+     * @return the configurationLock
+     */
+    public GeoServerConfigurationLock getConfigurationLock() {
+        return configurationLock;
     }
 }

--- a/cluster/src/main/java/org/geoserver/cluster/hazelcast/HzSynchronizer.java
+++ b/cluster/src/main/java/org/geoserver/cluster/hazelcast/HzSynchronizer.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.CatalogException;
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -64,15 +65,18 @@ public abstract class HzSynchronizer extends GeoServerSynchronizer implements Me
     ScheduledExecutorService executor;
 
     /** geoserver configuration */
-    protected GeoServer gs;
+    protected final GeoServer gs;
+
+    protected final GeoServerConfigurationLock geoServerConfigurationLock;
     
     ScheduledExecutorService getNewExecutor() {
         return Executors.newSingleThreadScheduledExecutor();
     }
     
-    public HzSynchronizer(HzCluster cluster, GeoServer gs) {
+    public HzSynchronizer(HzCluster cluster, GeoServer gs,GeoServerConfigurationLock geoServerConfigurationLock) {
         this.cluster = cluster;
         this.gs = gs;
+        this.geoServerConfigurationLock=geoServerConfigurationLock;
 
         topic = cluster.getHz().getTopic("geoserver.config");
         topic.addMessageListener(this);

--- a/cluster/src/main/java/org/geoserver/cluster/hazelcast/HzSynchronizerInitializer.java
+++ b/cluster/src/main/java/org/geoserver/cluster/hazelcast/HzSynchronizerInitializer.java
@@ -42,11 +42,11 @@ public class HzSynchronizerInitializer implements GeoServerInitializer {
         
         String method = config.getSyncMethod();
         if ("event".equalsIgnoreCase(method)) {
-            syncher = new EventHzSynchronizer(cluster, geoServer);
+            syncher = new EventHzSynchronizer(cluster, geoServer,cluster.getConfigurationLock());
         }
         else {
             method = "reload"; 
-            syncher = new ReloadHzSynchronizer(cluster, geoServer);
+            syncher = new ReloadHzSynchronizer(cluster, geoServer,cluster.getConfigurationLock());
         }
         
         syncher.initialize(configWatcher);

--- a/cluster/src/main/java/org/geoserver/cluster/hazelcast/ReloadHzSynchronizer.java
+++ b/cluster/src/main/java/org/geoserver/cluster/hazelcast/ReloadHzSynchronizer.java
@@ -4,6 +4,8 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.GeoServerConfigurationLock.LockType;
 import org.geoserver.cluster.Event;
 import org.geoserver.config.GeoServer;
 
@@ -19,14 +21,15 @@ public class ReloadHzSynchronizer extends HzSynchronizer {
     /** lock during reload */
     protected AtomicBoolean eventLock = new AtomicBoolean();
 
-    public ReloadHzSynchronizer(HzCluster cluster, GeoServer gs) {
-        super(cluster, gs);
+    public ReloadHzSynchronizer(HzCluster cluster, GeoServer gs, GeoServerConfigurationLock geoServerConfigurationLock) {
+        super(cluster, gs,geoServerConfigurationLock);
     }
     
     @Override
     protected void processEventQueue(Queue<Event> q) throws Exception {
         //lock during event processing
         eventLock.set(true);
+        geoServerConfigurationLock.lock(LockType.WRITE);
         try {
             gs.reload();
         } catch (Exception e) {
@@ -34,6 +37,7 @@ public class ReloadHzSynchronizer extends HzSynchronizer {
         }
         finally {
             q.clear();
+            geoServerConfigurationLock.unlock(LockType.WRITE);
             eventLock.set(false);
         }
     }

--- a/cluster/src/main/resources/applicationContext.xml
+++ b/cluster/src/main/resources/applicationContext.xml
@@ -12,9 +12,11 @@
          class="org.geoserver.cluster.hazelcast.HzSynchronizerInitializer">
       <property name="cluster" ref="hzCluster"/>
    </bean>
+   
    <bean id="hzCluster" 
          class="org.geoserver.cluster.hazelcast.HzCluster">
       <property name="dataDirectory" ref="dataDirectory"/>
+      <property name="configurationLock" ref="configurationLock"/>
    </bean>
 
 </beans>

--- a/cluster/src/test/java/org/geoserver/cluster/hazelcast/EventHzSynchronizerRecvTest.java
+++ b/cluster/src/test/java/org/geoserver/cluster/hazelcast/EventHzSynchronizerRecvTest.java
@@ -53,7 +53,7 @@ public class EventHzSynchronizerRecvTest extends HzSynchronizerRecvTest {
 
     @Override
     protected HzSynchronizer getSynchronizer() {
-        return new EventHzSynchronizer(cluster, getGeoServer()) {
+        return new EventHzSynchronizer(cluster, getGeoServer(),getConfigurationLock()) {
 
             @Override
             ScheduledExecutorService getNewExecutor() {

--- a/cluster/src/test/java/org/geoserver/cluster/hazelcast/EventHzSynchronizerSendTest.java
+++ b/cluster/src/test/java/org/geoserver/cluster/hazelcast/EventHzSynchronizerSendTest.java
@@ -6,7 +6,7 @@ public class EventHzSynchronizerSendTest extends HzSynchronizerSendTest {
 
     @Override
     protected HzSynchronizer getSynchronizer() {
-        return new EventHzSynchronizer(cluster, getGeoServer()) {
+        return new EventHzSynchronizer(cluster, getGeoServer(),getConfigurationLock()) {
 
             @Override
             ScheduledExecutorService getNewExecutor() {

--- a/cluster/src/test/java/org/geoserver/cluster/hazelcast/HzSynchronizerTest.java
+++ b/cluster/src/test/java/org/geoserver/cluster/hazelcast/HzSynchronizerTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.geoserver.GeoServerConfigurationLock;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.cluster.ClusterConfig;
@@ -24,6 +25,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MessageListener;
+
 import static org.easymock.EasyMock.*;
 
 public abstract class HzSynchronizerTest {
@@ -135,6 +137,10 @@ public abstract class HzSynchronizerTest {
     }
     protected Catalog getCatalog(){
         return catalog;
+    }
+    
+    protected GeoServerConfigurationLock getConfigurationLock(){
+        return EasyMock.createMock(GeoServerConfigurationLock.class);
     }
     
     /**

--- a/cluster/src/test/java/org/geoserver/cluster/hazelcast/ReloadHzSynchronizerRecvTest.java
+++ b/cluster/src/test/java/org/geoserver/cluster/hazelcast/ReloadHzSynchronizerRecvTest.java
@@ -16,7 +16,7 @@ public class ReloadHzSynchronizerRecvTest extends HzSynchronizerRecvTest {
 
     @Override
     protected HzSynchronizer getSynchronizer() {
-        return new ReloadHzSynchronizer(cluster, getGeoServer()) {
+        return new ReloadHzSynchronizer(cluster, getGeoServer(),getConfigurationLock()) {
 
             @Override
             ScheduledExecutorService getNewExecutor() {

--- a/cluster/src/test/java/org/geoserver/cluster/hazelcast/ReloadHzSynchronizerSendTest.java
+++ b/cluster/src/test/java/org/geoserver/cluster/hazelcast/ReloadHzSynchronizerSendTest.java
@@ -6,7 +6,7 @@ public class ReloadHzSynchronizerSendTest extends HzSynchronizerSendTest {
 
     @Override
     protected HzSynchronizer getSynchronizer() {
-        return new ReloadHzSynchronizer(cluster, getGeoServer()) {
+        return new ReloadHzSynchronizer(cluster, getGeoServer(),getConfigurationLock()) {
 
             @Override
             ScheduledExecutorService getNewExecutor() {


### PR DESCRIPTION
I believe that before processing events coming from a remote node we should acquire a lock on the global configuration lock to make sure we don't mess up with the catalog on that same instance via REST or GUI.
Actually it might be worth (side note) to investigate extending the Config Lock to use Hazelcast distributed locks.
