### PR TITLE
Fix error retrieving mongodb datastore

### DIFF
--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
@@ -21,6 +21,7 @@ import org.geotools.data.store.ContentDataStore;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.data.store.ContentState;
+import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.FilterCapabilities;
 import org.geotools.referencing.CRS;
@@ -281,7 +282,7 @@ public class MongoDataStore extends ContentDataStore {
         
         List<Name> typeNameList = new ArrayList<Name>();
         for (String name : typeNameSet) {
-            typeNameList.add(name(name));
+            typeNameList.add(new NameImpl(namespaceURI, name));
         }
         
         return typeNameList;

--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStoreFactory.java
@@ -2,6 +2,7 @@ package org.geotools.data.mongodb;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.Map;
 import org.geotools.data.AbstractDataStoreFactory;
 import org.geotools.data.DataStore;
@@ -10,6 +11,7 @@ public class MongoDataStoreFactory extends AbstractDataStoreFactory {
 
     public static final Param DATASTORE_URI = new Param("data_store", String.class, "MongoDB URI", true, "mongodb://localhost/<database name>");
     public static final Param SCHEMASTORE_URI = new Param("schema_store", String.class, "Schema Store URI", true, "file://<absolute path>");
+    public static final Param NAMESPACEP = new Param("namespace", URI.class, "get uri from workspace", false, null);
     
     @Override
     public String getDisplayName() {
@@ -23,13 +25,18 @@ public class MongoDataStoreFactory extends AbstractDataStoreFactory {
     
     @Override
     public Param[] getParametersInfo() {
-        return new Param[]{DATASTORE_URI, SCHEMASTORE_URI};
+        return new Param[]{NAMESPACEP, DATASTORE_URI, SCHEMASTORE_URI};
     }
 
     @Override
     public MongoDataStore createDataStore(Map<String, Serializable> params) throws IOException {
-        return new MongoDataStore(
+        MongoDataStore store = new MongoDataStore(
                 (String)DATASTORE_URI.lookUp(params), (String)SCHEMASTORE_URI.lookUp(params));
+        URI namespace = (URI)NAMESPACEP.lookUp(params);
+        if (namespace != null) {
+            store.setNamespaceURI(namespace.toString());
+        }
+        return store;
     }
 
     @Override

--- a/mongodb/src/test/java/org/geotools/data/mongodb/FeatureTypeDBObjectTest.java
+++ b/mongodb/src/test/java/org/geotools/data/mongodb/FeatureTypeDBObjectTest.java
@@ -109,7 +109,7 @@ public class FeatureTypeDBObjectTest {
         assertThat(right.getTypeName(), is(equalTo(left.getTypeName())));
         // verify feature type user data persisted
         Map<?,?> resultUserData = right.getUserData();
-        Map<?,?> originalUserData = left.getUserData();
+        Map<Object,Object> originalUserData = left.getUserData();
         assertThat(resultUserData.size(), is(equalTo(originalUserData.size())));
         for (Map.Entry entry : resultUserData.entrySet()) {
             assertThat(entry.getValue(), is(equalTo(originalUserData.get(entry.getKey()))));
@@ -144,7 +144,7 @@ public class FeatureTypeDBObjectTest {
                 assertThat(rad.getType().getBinding().getSimpleName(), is(equalTo(oad.getType().getBinding().getSimpleName())));
             }
             Map<?,?> radUserData = rad.getUserData();
-            Map<?,?> oadUserData = oad.getUserData();
+            Map<Object,Object> oadUserData = oad.getUserData();
             assertThat(radUserData.size(), is(equalTo(oadUserData.size())));
             for (Map.Entry entry : radUserData.entrySet()) {
                 assertThat(entry.getValue(), is(equalTo(oadUserData.get(entry.getKey()))));

--- a/web/app/pom.xml
+++ b/web/app/pom.xml
@@ -75,6 +75,11 @@
    <artifactId>gs-ysld</artifactId>
    <version>${gs.version}</version>
   </dependency>
+  <dependency>
+   <groupId>org.opengeo</groupId>
+   <artifactId>gt-mongodb</artifactId>
+   <version>${gs.version}</version>
+  </dependency>
 
   <dependency>
    <groupId>org.mortbay.jetty</groupId>


### PR DESCRIPTION
mongodb extension is not usable on GeoServer 2.6.0.

Datastores and layers can be created, but cannot be used, throwing an error because GeoServer tries to locate the qualified name featuretype, while the existing featuretype was unqualified. Error is "Schema <namespace>:<layername> does not exist": https://github.com/geotools/geotools/blob/master/modules/library/data/src/main/java/org/geotools/data/store/ContentDataStore.java#L619

This patch propagates the workspace's namespace to mongodb DataStores and their respective FeatureTypes (Shapefile datastore has been taken as reference), so the extension works in GS 2.6.x again.

Sorry, no unit tests included. But the error is easily reproducible just trying to preview any mongodb layer on GS 2.6.
