### PR TITLE
Encode filters with embeded CQL markers

### DIFF
--- a/ysld/gt-ysld/src/main/java/org/geotools/ysld/encode/RuleEncoder.java
+++ b/ysld/gt-ysld/src/main/java/org/geotools/ysld/encode/RuleEncoder.java
@@ -19,21 +19,21 @@ public class RuleEncoder extends YsldEncodeHandler<Rule> {
         put("title", rule.getTitle());
         put("abstract", rule.getAbstract());
         if (rule.getFilter() != null && rule.getFilter() != Filter.INCLUDE) {
-            put("filter", ECQL.toCQL(rule.getFilter()));
+            put("filter", String.format("${%s}", escapeForEmbededCQL(ECQL.toCQL(rule.getFilter()))));
         }
         if (rule.isElseFilter()) {
             put("else", true);
         }
-
+        
         Tuple t = Tuple.of(toStringOrNull(rule.getMinScaleDenominator()), toStringOrNull(rule.getMaxScaleDenominator()));
         if (!t.isNull()) {
             put("scale", t.toString());
         }
-
+        
         //legend:?
         put("symbolizers", new SymbolizersEncoder(rule));
     }
-
+    
     String toStringOrNull(double d) {
         return d > 0 && !Double.isNaN(d) && !Double.isInfinite(d) ? String.valueOf(d) : null;
     }

--- a/ysld/gt-ysld/src/main/java/org/geotools/ysld/encode/YsldEncodeHandler.java
+++ b/ysld/gt-ysld/src/main/java/org/geotools/ysld/encode/YsldEncodeHandler.java
@@ -164,9 +164,9 @@ public abstract class YsldEncodeHandler<T> implements Iterator<Object> {
         }
     }
     
-    static final Pattern EMBEDED_EXPRESSION_ESCAPE = Pattern.compile("[$}\\\\]");
+    static final Pattern EMBEDED_EXPRESSION_TO_ESCAPE = Pattern.compile("[$}\\\\]");
     String escapeForEmbededCQL(String s) {
-        return EMBEDED_EXPRESSION_ESCAPE.matcher(s).replaceAll("\\\\$0");
+        return EMBEDED_EXPRESSION_TO_ESCAPE.matcher(s).replaceAll("\\\\$0");
     }
     
     Object toObjOrNull(Expression expr, boolean isname) {

--- a/ysld/gt-ysld/src/main/java/org/geotools/ysld/parse/Util.java
+++ b/ysld/gt-ysld/src/main/java/org/geotools/ysld/parse/Util.java
@@ -234,9 +234,12 @@ public class Util {
         return WellKnownZoomContextFinder.getInstance().get(name);
     }
     
+    static final Pattern EMBEDED_EXPRESSION_ESCAPED = Pattern.compile("\\\\([$}\\\\])");
+    static final Pattern EMBEDED_FILTER = Pattern.compile("^\\s*\\$\\{(.*?)\\}\\s*$");
     public static String removeExpressionBrackets(String s) {
-        if(s.startsWith("${") && s.endsWith("}")) {
-            return s.substring(2, s.length()-1);
+        Matcher m1 = EMBEDED_FILTER.matcher(s);
+        if(m1.matches()) {
+            return EMBEDED_EXPRESSION_ESCAPED.matcher(m1.group(1)).replaceAll("$1");
         }
         return s;
     }

--- a/ysld/gt-ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeCookbookTest.java
+++ b/ysld/gt-ysld/src/test/java/org/geotools/ysld/encode/YsldEncodeCookbookTest.java
@@ -276,15 +276,15 @@ public class YsldEncodeCookbookTest {
 
         YamlMap rule = style.seq("feature-styles").map(0).seq("rules").map(0);
         assertEquals("SmallPop", rule.str("name"));
-        assertEquals("pop < '50000'", rule.str("filter"));
+        assertEquals("${pop < '50000'}", rule.str("filter"));
 
         rule = style.seq("feature-styles").map(0).seq("rules").map(1);
         assertEquals("MediumPop", rule.str("name"));
-        assertEquals("pop >= '50000' AND pop < '100000'", rule.str("filter"));
+        assertEquals("${pop >= '50000' AND pop < '100000'}", rule.str("filter"));
 
         rule = style.seq("feature-styles").map(0).seq("rules").map(2);
         assertEquals("LargePop", rule.str("name"));
-        assertEquals("pop >= '100000'", rule.str("filter"));
+        assertEquals("${pop >= '100000'}", rule.str("filter"));
     }
 
     @Test
@@ -590,7 +590,7 @@ public class YsldEncodeCookbookTest {
 
         YamlMap rule = style.seq("feature-styles").map(0).seq("rules").map(0);
         assertEquals("local-road", rule.str("name"));
-        assertEquals("type = 'local-road'", rule.str("filter"));
+        assertEquals("${type = 'local-road'}", rule.str("filter"));
 
         YamlMap line = rule.seq("symbolizers").map(0).map("line");
         assertThat(line.get("stroke-color"), isColor("009933"));
@@ -598,7 +598,7 @@ public class YsldEncodeCookbookTest {
 
         rule = style.seq("feature-styles").map(1).seq("rules").map(0);
         assertEquals("secondary", rule.str("name"));
-        assertEquals("type = 'secondary'", rule.str("filter"));
+        assertEquals("${type = 'secondary'}", rule.str("filter"));
 
         line = rule.seq("symbolizers").map(0).map("line");
         assertThat(line.get("stroke-color"), isColor("0055CC"));
@@ -606,7 +606,7 @@ public class YsldEncodeCookbookTest {
 
         rule = style.seq("feature-styles").map(2).seq("rules").map(0);
         assertEquals("highway", rule.str("name"));
-        assertEquals("type = 'highway'", rule.str("filter"));
+        assertEquals("${type = 'highway'}", rule.str("filter"));
 
         line = rule.seq("symbolizers").map(0).map("line");
         assertThat(line.get("stroke-color"), isColor("FF0000"));
@@ -1137,21 +1137,21 @@ public class YsldEncodeCookbookTest {
 
         YamlMap rule = obj.seq("feature-styles").map(0).seq("rules").map(0);
         assertEquals("SmallPop", rule.str("name"));
-        assertEquals("pop < '200000'", rule.str("filter"));
+        assertEquals("${pop < '200000'}", rule.str("filter"));
 
         YamlMap poly = rule.seq("symbolizers").map(0).map("polygon");
         assertThat(poly.get("fill-color"), isColor("66FF66"));
 
         rule = obj.seq("feature-styles").map(0).seq("rules").map(1);
         assertEquals("MediumPop", rule.str("name"));
-        assertEquals("pop >= '200000' AND pop < '500000'", rule.str("filter"));
+        assertEquals("${pop >= '200000' AND pop < '500000'}", rule.str("filter"));
 
         poly = rule.seq("symbolizers").map(0).map("polygon");
         assertThat(poly.get("fill-color"), isColor("33CC33"));
 
         rule = obj.seq("feature-styles").map(0).seq("rules").map(2);
         assertEquals("LargePop", rule.str("name"));
-        assertEquals("pop > '500000'", rule.str("filter"));
+        assertEquals("${pop > '500000'}", rule.str("filter"));
 
         poly = rule.seq("symbolizers").map(0).map("polygon");
         assertThat(poly.get("fill-color"), isColor("009900"));


### PR DESCRIPTION
Switch to using ${} around filters when encoding.  Escape and respect escaping of filters when using this notation.
