### PR TITLE
YsldInput now properly closes readers

### DIFF
--- a/ysld/gt-ysld/src/main/java/org/geotools/ysld/Ysld.java
+++ b/ysld/gt-ysld/src/main/java/org/geotools/ysld/Ysld.java
@@ -51,12 +51,7 @@ public class Ysld {
             return new YsldInput(new BufferedReader(new InputStreamReader((InputStream)input)));
         }
         else if (input instanceof File) {
-            return new YsldInput(new BufferedReader(new FileReader((File)input))) {
-                @Override
-                public void close() throws IOException {
-                    reader.close();
-                }
-            };
+            return new YsldInput(new BufferedReader(new FileReader((File)input)));
         }
         else if (input instanceof String) {
             return new YsldInput(new StringReader((String)input));
@@ -233,6 +228,7 @@ public class Ysld {
         }
 
         public void close() throws IOException {
+            reader.close();
         }
     }
 }

--- a/ysld/gt-ysld/src/test/java/org/geotools/ysld/YsldTest.java
+++ b/ysld/gt-ysld/src/test/java/org/geotools/ysld/YsldTest.java
@@ -1,0 +1,27 @@
+package org.geotools.ysld;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.geotools.ysld.Ysld.YsldInput;
+import org.junit.Test;
+
+public class YsldTest {
+    
+    @Test
+    public void readerTest() throws IOException {
+        InputStream inputStream = YsldTest.class.getResourceAsStream("point.yml");
+        YsldInput reader = Ysld.reader(inputStream);
+        reader.close();
+        try {
+            inputStream.read();
+            fail("inputStream should be closed");
+        } catch (IOException e) {
+            //expect IOException reading from a closed reader
+        }
+        
+    }
+
+}


### PR DESCRIPTION
reader.close() is now called when any YsldInput is closed, not just a file-based one.
Added test case for input streams. Should probably expand this to handle every possible type of reader.
