### PR TITLE
Added constructor to match bean in applicationContext

### DIFF
--- a/ysld/gs-ysld/src/main/java/org/geoserver/ysld/YsldHandler.java
+++ b/ysld/gs-ysld/src/main/java/org/geoserver/ysld/YsldHandler.java
@@ -32,6 +32,9 @@ public class YsldHandler extends StyleHandler {
         super("Ysld", FORMAT);
         this.zoomFinder = zoomFinder;
     }
+    public YsldHandler(ZoomContextFinder zoomFinder) {
+        this(zoomFinder, new UomMapper());
+    }
 
     /**
      * Creates a new handler.


### PR DESCRIPTION
I just have this create a new UomMapper() - is this fine for bean initialization @smithkm or does a UomMapper bean need to be added to the application context?