### PR TITLE
mongodb getWriterInternal no longer returns null for WRITER_COMMIT flag

### DIFF
--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureStore.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoFeatureStore.java
@@ -82,7 +82,7 @@ public class MongoFeatureStore extends ContentFeatureStore {
     @Override
     protected FeatureWriter<SimpleFeatureType, SimpleFeature> getWriterInternal(
         Query query, int flags) throws IOException {
-        if ((flags & (WRITER_ADD | WRITER_UPDATE)) != 0) {
+        if ((flags & (WRITER_ADD | WRITER_UPDATE | WRITER_COMMIT)) != 0) {
             return new MongoFeatureWriter(delegate.getCollection(), getSchema(), this);
         }
         return null;


### PR DESCRIPTION
Updated the mongodb getWriterInternal to support the new WRITER_COMMIT flag (added in GeoTools 13).
This fix has been sucessfully tested with Suite 4.6 on Ubuntu.
Proper handling of flags something the mongodb writer should probably support - right now it just checks if the flags are valid, but otherwise behaves the same.