### PR TITLE
MongoDB plugin ignores arrays when generating a schema

### DIFF
--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoDBObjectFeature.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoDBObjectFeature.java
@@ -83,8 +83,8 @@ public class MongoDBObjectFeature implements SimpleFeature {
 
     @Override
     public Object getDefaultGeometry() {
-        Object o = getDBOValue(mapper.getGeometryPath());
-        return o instanceof DBObject ? mapper.getGeometry((DBObject)o) : null;
+        Object o = mapper.getGeometry(featureDBO);
+        return o instanceof Geometry ? o : null;
     }
 
     @Override

--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoDataStore.java
@@ -198,8 +198,7 @@ public class MongoDataStore extends ContentDataStore {
         incoming.getUserData().put(KEY_collection, incoming.getTypeName());
         
         // Collection needs to exist (with index) so that it's returned with createTypeNames()
-        dataStoreDB.createCollection(incoming.getTypeName(), new BasicDBObject())
-                .ensureIndex(new BasicDBObject(geometryMapping, "2dsphere"));
+        dataStoreDB.createCollection(incoming.getTypeName(), new BasicDBObject()).ensureIndex(new BasicDBObject(geometryMapping, "2dsphere"));
        
         // Store FeatureType instance since it can't be inferred (no documents)
         ContentEntry entry = entry (incoming.getName());

--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoInferredMapper.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoInferredMapper.java
@@ -4,11 +4,15 @@ package org.geotools.data.mongodb;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.vividsolutions.jts.geom.Geometry;
+
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.util.logging.Logging;
@@ -78,6 +82,18 @@ public class MongoInferredMapper extends AbstractCollectionMapper {
                     break;
                 }
             }
+        }
+        
+        //Examine the DBO and remove any invalid indexed fields (such as arrays)
+        DBObject dbo = collection.findOne();
+        if (dbo != null) {
+        	Iterator<String> indexedIterator = indexedFields.iterator();
+        	while (indexedIterator.hasNext()) {
+        		Object value = MongoUtil.getDBOValue(dbo, indexedIterator.next());
+        		if (value == null) {
+        			indexedIterator.remove();
+        		}
+        	}
         }
         
         SimpleFeatureTypeBuilder ftBuilder = new SimpleFeatureTypeBuilder();

--- a/mongodb/src/main/java/org/geotools/data/mongodb/MongoUtil.java
+++ b/mongodb/src/main/java/org/geotools/data/mongodb/MongoUtil.java
@@ -3,9 +3,11 @@
  */
 package org.geotools.data.mongodb;
 
+import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -21,7 +23,7 @@ import java.util.Set;
  * @author tkunicki@boundlessgeo.com
  */
 public class MongoUtil {
-    
+	
     public static Object getDBOValue(DBObject dbo, String path) {
         return getDBOValue(dbo, Arrays.asList(path.split("\\.")).iterator());
     }
@@ -34,6 +36,14 @@ public class MongoUtil {
         if (path.hasNext()) {
             if (current instanceof DBObject) {
                 String key = path.next();
+                //If we are in an array, key must be an int
+            	if (current instanceof BasicDBList) {
+            		try {
+            			Integer.parseInt(key);
+            		} catch (NumberFormatException e) {
+            			return null;
+            		}
+            	}
                 Object value = ((DBObject)current).get(key);
                 return getDBOValueInternal(path, value);
             }
@@ -116,9 +126,13 @@ public class MongoUtil {
                 String field = (String)k;
                 Object v = e.getValue();
                 if (v instanceof DBObject) {
-                    for (Map.Entry<String, Class<?>> childEntry : doFindMappableFields((DBObject)v).entrySet()) {
-                        map.put(field + "." + childEntry.getKey(), childEntry.getValue());
-                    }
+                	if (v instanceof BasicDBList) {
+                		//No list support
+                	} else {
+	                    for (Map.Entry<String, Class<?>> childEntry : doFindMappableFields((DBObject)v).entrySet()) {
+	                        map.put(field + "." + childEntry.getKey(), childEntry.getValue());
+	                    }
+                	}
                 } else if (v instanceof List) {
                     // this is here as documentation/placeholder.  no array/list support yet.
                 } else {

--- a/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
+++ b/mongodb/src/test/java/org/geotools/data/mongodb/MongoDataStoreTest.java
@@ -13,6 +13,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.GeometryBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
@@ -73,9 +74,9 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
 
         GeometryBuilder gb = new GeometryBuilder();
         f.setDefaultGeometry(gb.point(3, 3));
-        f.setAttribute("intProperty", 3);
-        f.setAttribute("doubleProperty", 3.3);
-        f.setAttribute("stringProperty", "three");
+        f.setAttribute("properties.intProperty", 3);
+        f.setAttribute("properties.doubleProperty", 3.3);
+        f.setAttribute("properties.stringProperty", "three");
         w.write();
         w.close();
     }
@@ -83,6 +84,12 @@ public abstract class MongoDataStoreTest extends MongoTestSupport {
     public void testCreateSchema() throws Exception {
         SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
         tb.setName("ft2");
+        tb.add("intProperty", Integer.class);
+        tb.add("doubleProperty", Double.class);
+        tb.add("stringProperty", String.class);
+        
+        tb.setCRS(DefaultGeographicCRS.WGS84);
+        tb.add("geometry", Point.class);
 
         List<String> typeNames = Arrays.asList(dataStore.getTypeNames());
         assertFalse(typeNames.contains("ft2"));

--- a/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
+++ b/mongodb/src/test/java/org/geotools/data/mongodb/MongoFeatureSourceTest.java
@@ -6,6 +6,7 @@ import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;
 import org.opengis.filter.spatial.BBOX;
@@ -24,7 +25,7 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
       Query q = new Query("ft1", f);
       assertEquals(1, source.getCount(q));
-      assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,null), source.getBounds(q));
+      assertEquals(new ReferencedEnvelope(1d,1d,1d,1d,DefaultGeographicCRS.WGS84), source.getBounds(q));
 
       SimpleFeatureCollection features = source.getFeatures(q);
       SimpleFeatureIterator it = features.features();
@@ -39,13 +40,13 @@ public abstract class MongoFeatureSourceTest extends MongoTestSupport {
 
     public void testEqualToFilter() throws Exception {
         FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
-        PropertyIsEqualTo f = ff.equals(ff.property("stringProperty"), ff.literal("two"));
+        PropertyIsEqualTo f = ff.equals(ff.property("properties.stringProperty"), ff.literal("two"));
 
         SimpleFeatureSource source = dataStore.getFeatureSource("ft1");
         Query q = new Query("ft1", f);
         
         assertEquals(1, source.getCount(q));
-        assertEquals(new ReferencedEnvelope(2d,2d,2d,2d,null), source.getBounds(q));
+        assertEquals(new ReferencedEnvelope(2d,2d,2d,2d,DefaultGeographicCRS.WGS84), source.getBounds(q));
 
         SimpleFeatureCollection features = source.getFeatures(q);
         SimpleFeatureIterator it = features.features();

--- a/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
+++ b/mongodb/src/test/java/org/geotools/data/mongodb/MongoTestSupport.java
@@ -4,7 +4,10 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.vividsolutions.jts.geom.Point;
+
 import java.util.Properties;
+import java.util.Set;
+
 import org.geotools.test.OnlineTestCase;
 import org.opengis.feature.simple.SimpleFeature;
 
@@ -41,7 +44,7 @@ public abstract class MongoTestSupport extends OnlineTestCase {
     }
 
     protected void setUp(DB db) throws Exception {
-        testSetup.setUp(db);
+    	testSetup.setUp(db);
         dataStore = testSetup.createDataStore(fixture);
     }
 
@@ -60,7 +63,7 @@ public abstract class MongoTestSupport extends OnlineTestCase {
     }
 
     protected void assertFeature(SimpleFeature f) {
-        int i = (Integer) f.getAttribute("intProperty");
+        int i = (Integer) f.getAttribute("properties.intProperty");
         assertFeature(f, i);
     }
     
@@ -68,16 +71,16 @@ public abstract class MongoTestSupport extends OnlineTestCase {
         assertNotNull(f.getDefaultGeometry());
         Point p = (Point) f.getDefaultGeometry();
 
-        assertNotNull(f.getAttribute("intProperty"));
+        assertNotNull(f.getAttribute("properties.intProperty"));
 
         assertEquals((double)i, p.getX(), 0.1);
         assertEquals((double)i, p.getY(), 0.1);
 
-        assertNotNull(f.getAttribute("doubleProperty"));
-        assertEquals(i + i*0.1, (Double)f.getAttribute("doubleProperty"), 0.1);
+        assertNotNull(f.getAttribute("properties.doubleProperty"));
+        assertEquals(i + i*0.1, (Double)f.getAttribute("properties.doubleProperty"), 0.1);
 
-        assertNotNull(f.getAttribute("stringProperty"));
-        assertEquals(toString(i), (String)f.getAttribute("stringProperty"));
+        assertNotNull(f.getAttribute("properties.stringProperty"));
+        assertEquals(toString(i), (String)f.getAttribute("properties.stringProperty"));
     }
 
     protected String toString(int i) {

--- a/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -1,17 +1,25 @@
 package org.geotools.data.mongodb.geojson;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
+import com.vividsolutions.jts.geom.Point;
+
 import org.geotools.data.mongodb.MongoDataStore;
 import org.geotools.data.mongodb.MongoTestSetup;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 
 public class GeoJSONMongoTestSetup extends MongoTestSetup {
 
     @Override
     protected void setUpDataStore(MongoDataStore dataStore) {
-
+    	
     }
 
     @Override
@@ -56,10 +64,11 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
             .pop()
         .get());
 
-        ft1.ensureIndex(new BasicDBObject("geometry.coordinates", "2d"));
+        ft1.ensureIndex(new BasicDBObject("geometry", "2dsphere"));
 
         DBCollection ft2 = db.getCollection("ft2");
         ft2.drop();
+        
     }
 
 }

--- a/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
+++ b/mongodb/src/test/java/org/geotools/data/mongodb/geojson/GeoJSONMongoTestSetup.java
@@ -37,6 +37,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 .add("intProperty", 0)
                 .add("doubleProperty", 0.0)
                 .add("stringProperty", "zero")
+                .add("listProperty", list(new BasicDBObject("value", 0.1),new BasicDBObject("value", 0.2)))
             .pop()
         .get());
         ft1.save(BasicDBObjectBuilder.start()
@@ -49,6 +50,7 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 .add("intProperty", 1)
                 .add("doubleProperty", 1.1)
                 .add("stringProperty", "one")
+                .add("listProperty", list(new BasicDBObject("value", 1.1),new BasicDBObject("value", 1.2)))
             .pop()
         .get());
         ft1.save(BasicDBObjectBuilder.start()
@@ -61,10 +63,12 @@ public class GeoJSONMongoTestSetup extends MongoTestSetup {
                 .add("intProperty", 2)
                 .add("doubleProperty", 2.2)
                 .add("stringProperty", "two")
+                .add("listProperty", list(new BasicDBObject("value", 2.1),new BasicDBObject("value", 2.2)))
             .pop()
         .get());
 
         ft1.ensureIndex(new BasicDBObject("geometry", "2dsphere"));
+        ft1.ensureIndex(new BasicDBObject("properties.listProperty.value", 1));
 
         DBCollection ft2 = db.getCollection("ft2");
         ft2.drop();


### PR DESCRIPTION
Fix for #83 

When generating schemas, the mongodb plugin now ignores Array values. If an index points to an array value, it will not be included in the schema.
When looking up values in arrays, the mongodb plugin will check if the key is valid.
Added test for indexed array values.

Test cases for the mongodb plugin have been fixed