### PR TITLE
Capitalize YSLD

### DIFF
--- a/ysld/gs-ysld/src/main/java/org/geoserver/ysld/YsldHandler.java
+++ b/ysld/gs-ysld/src/main/java/org/geoserver/ysld/YsldHandler.java
@@ -29,7 +29,7 @@ public class YsldHandler extends StyleHandler {
      * Creates a new handler with an explicit zoom finder.
      */
     public YsldHandler(ZoomContextFinder zoomFinder, UomMapper uomMapper) {
-        super("Ysld", FORMAT);
+        super("YSLD", FORMAT);
         this.zoomFinder = zoomFinder;
     }
 


### PR DESCRIPTION
Capitalize "YSLD" in the GeoServer UI to be consistent with "SLD"