### PR TITLE
Updated YSLD error message for invalid color

### DIFF
--- a/ysld/gt-ysld/src/main/java/org/geotools/ysld/validate/ColorValidator.java
+++ b/ysld/gt-ysld/src/main/java/org/geotools/ysld/validate/ColorValidator.java
@@ -16,7 +16,7 @@ public class ColorValidator extends ScalarValidator {
             if (expr instanceof Literal) {
                 Color col = expr.evaluate(null, Color.class);
                 if (col == null) {
-                    return "Invalid color, must be one of: 0xrrggbb, rgb(r,g,b), or expression";
+                    return "Invalid color, must be one of: '#RRGGBB', rgb(r,g,b), or expression";
                 }
             }
             return null;


### PR DESCRIPTION
The current YSLD docs use '#RRGGBB' for hex colors, not 0xrrggbb