### PR TITLE
Cherry pick "Adapt to GeoGig API change" onto the 2.6.x branch.

### DIFF
--- a/geogig/src/main/java/org/geogig/geoserver/config/DeprecatedDataStoreConfigFixer.java
+++ b/geogig/src/main/java/org/geogig/geoserver/config/DeprecatedDataStoreConfigFixer.java
@@ -105,7 +105,7 @@ class DeprecatedDataStoreConfigFixer implements CatalogListener {
                 try {
                     if (Boolean.TRUE.equals(CREATE.lookUp(params))) {
                         DataAccess<? extends FeatureType, ? extends Feature> dataStore;
-                        dataStore = ds.getDataStore(null);
+                        dataStore = new GeoGigDataStoreFactory().createDataStore(params);
                         dataStore.dispose();
                     }
                 } catch (IOException e) {

--- a/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java
+++ b/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java
@@ -1,7 +1,7 @@
 package org.geogig.geoserver.config;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 
 import org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory;
 
@@ -10,11 +10,11 @@ import com.google.common.base.Throwables;
 public class GeoServerStoreRepositoryResolver implements GeoGigDataStoreFactory.RepositoryLookup {
 
     @Override
-    public File resolve(final String repository) {
+    public URI resolve(final String repository) {
         RepositoryManager repositoryManager = RepositoryManager.get();
         try {
             RepositoryInfo info = repositoryManager.get(repository);
-            return new File(info.getLocation());
+            return URI.create(info.getLocation());
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
+++ b/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java
@@ -4,7 +4,7 @@ import static java.lang.String.format;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -35,7 +35,7 @@ class RepositoryCache {
                 GeoGIG geogig = notification.getValue();
                 if (geogig != null) {
                     try {
-                        URL location = geogig.getRepository().getLocation();
+                        URI location = geogig.getRepository().getLocation();
                         LOGGER.fine(format("Closing cached GeoGig repository instance %s", location));
                         geogig.close();
                         LOGGER.finer(format("Closed cached GeoGig repository instance %s", location));

--- a/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java
+++ b/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java
@@ -285,8 +285,8 @@ public class RepositoryManager {
         Optional<IRemoteRepo> remoteRepo;
         try {
             Hints hints = Hints.readOnly();
-            remoteRepo = RemoteUtils.newRemote(GlobalContextBuilder.builder.build(hints), remote,
-                    null, null);
+            Repository localRepo = GlobalContextBuilder.builder.build(hints).repository();
+            remoteRepo = RemoteUtils.newRemote(localRepo, remote, null);
             if (!remoteRepo.isPresent()) {
                 throw new IllegalArgumentException("Repository not found or not reachable");
             } else {
@@ -296,11 +296,7 @@ public class RepositoryManager {
                     Ref head = repo.headRef();
                     return head;
                 } finally {
-                    try {
-                        repo.close();
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
+                    repo.close();
                 }
             }
         } catch (Exception e) {

--- a/geogig/src/main/java/org/geogig/geoserver/security/SecurityLogger.java
+++ b/geogig/src/main/java/org/geogig/geoserver/security/SecurityLogger.java
@@ -3,8 +3,7 @@ package org.geogig.geoserver.security;
 import static java.lang.String.format;
 
 import java.io.File;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -120,19 +119,19 @@ public class SecurityLogger {
         if (repository == null) {
             return null;
         }
-        URL location = repository.getLocation();
+        URI location = repository.getLocation();
         if (location == null) {
             return null;
         }
         String uri;
         try {
-            File f = new File(location.toURI());
+            File f = new File(location);
             if (f.getName().endsWith(".geogig")) {
                 f = f.getParentFile();
             }
             uri = f.getAbsolutePath();
-        } catch (URISyntaxException e) {
-            uri = location.toExternalForm();
+        } catch (Exception e) {
+            uri = location.toString();
         }
         return uri;
     }


### PR DESCRIPTION
The 2.6.x branch fails without 9fcadf52b4cc224f7c48ee0ad4bb1350b0ca3857.
```
[INFO] ------------------------------------------------------------------------
[INFO] Building GeoGig GeoServer integration 2.6-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- git-commit-id-plugin:2.1.8:revision (default) @ gs-geogig ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ gs-geogig ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 16 resources
[INFO] Copying 19 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ gs-geogig ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 45 source files to /home/vagrant/geoserver-exts/geogig/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java:[288,36] error: method newRemote in class RemoteUtils cannot be applied to given types;
[ERROR]   required: Repository,Remote,Hints
  found: Context,Remote,<null>,<null>
  reason: actual and formal argument lists differ in length
/home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java:[38,73] error: incompatible types
[ERROR]   required: URL
  found:    URI
/home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/security/SecurityLogger.java:[123,45] error: incompatible types
[ERROR]   required: URL
  found:    URI
/home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java:[10,7] error: GeoServerStoreRepositoryResolver is not abstract and does not override abstract method resolve(String) in RepositoryLookup
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java:[13,16] error: resolve(String) in GeoServerStoreRepositoryResolver cannot implement resolve(String) in RepositoryLookup
[ERROR]   return type File is not compatible with URI
/home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java:[12,4] error: method does not override or implement a method from a supertype
[INFO] 6 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] OpenGeo GeoServer Extensions ...................... SUCCESS [2.407s]
[INFO] Metrics Modules ................................... SUCCESS [0.252s]
[INFO] Metrics Base Module ............................... SUCCESS [1.089s]
[INFO] GeoServer Clustering Module ....................... SUCCESS [1.596s]
[INFO] Common Metrics Module ............................. SUCCESS [0.339s]
[INFO] WMS Metrics Module ................................ SUCCESS [1.718s]
[INFO] Mapmeter Extension ................................ SUCCESS [0.481s]
[INFO] GeoServer Printing Extension ...................... SUCCESS [0.571s]
[INFO] OpenGeo GeoServer Web UI Extensions ............... SUCCESS [0.132s]
[INFO] OpenGeo WPS GUI Extensions ........................ SUCCESS [0.633s]
[INFO] GeoServer GeoServices REST API .................... SUCCESS [0.525s]
[INFO] Ysld .............................................. SUCCESS [0.144s]
[INFO] Ysld Parser/Encoder ............................... SUCCESS [2.684s]
[INFO] Ysld GeoServer Plugin ............................. SUCCESS [0.240s]
[INFO] GeoServer Test Web App Module ..................... SUCCESS [2.786s]
[INFO] MongoDB DataStore ................................. SUCCESS [0.545s]
[INFO] GeoGig GeoServer integration ...................... FAILURE [4.592s]
[INFO] ESRI File GeoDatabase Support ..................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.434s
[INFO] Finished at: Fri Aug 07 19:40:46 UTC 2015
[INFO] Final Memory: 52M/260M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project gs-geogig: Compilation failure: Compilation failure:
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/RepositoryManager.java:[288,36] error: method newRemote in class RemoteUtils cannot be applied to given types;
[ERROR] required: Repository,Remote,Hints
[ERROR] found: Context,Remote,<null>,<null>
[ERROR] reason: actual and formal argument lists differ in length
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/RepositoryCache.java:[38,73] error: incompatible types
[ERROR] required: URL
[ERROR] found:    URI
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/security/SecurityLogger.java:[123,45] error: incompatible types
[ERROR] required: URL
[ERROR] found:    URI
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java:[10,7] error: GeoServerStoreRepositoryResolver is not abstract and does not override abstract method resolve(String) in RepositoryLookup
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java:[13,16] error: resolve(String) in GeoServerStoreRepositoryResolver cannot implement resolve(String) in RepositoryLookup
[ERROR] return type File is not compatible with URI
[ERROR] /home/vagrant/geoserver-exts/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java:[12,4] error: method does not override or implement a method from a supertype
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :gs-geogig
```