### PR TITLE
GeoGig File URI fix

### DIFF
--- a/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java
+++ b/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java
@@ -3,10 +3,10 @@ package org.geogig.geoserver.config;
 import java.io.IOException;
 import java.net.URI;
 
-import org.apache.commons.io.FilenameUtils;
 import org.locationtech.geogig.geotools.data.GeoGigDataStoreFactory;
 
 import com.google.common.base.Throwables;
+import java.io.File;
 
 public class GeoServerStoreRepositoryResolver implements GeoGigDataStoreFactory.RepositoryLookup {
 
@@ -15,12 +15,8 @@ public class GeoServerStoreRepositoryResolver implements GeoGigDataStoreFactory.
         RepositoryManager repositoryManager = RepositoryManager.get();
         try {
             RepositoryInfo info = repositoryManager.get(repository);
-            //enforce unix file seperators
-            String unixsep = FilenameUtils.separatorsToUnix(info.getLocation());
-            //check if refers to file, if it does add the file prefix
-            if(FilenameUtils.getPrefix(unixsep)!=null&&!unixsep.startsWith("file://"))
-            	unixsep = "file://"+unixsep;
-            return URI.create(unixsep);
+            File locFile = new File(info.getLocation());
+            return locFile.toURI();
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java
+++ b/geogig/src/main/java/org/geogig/geoserver/config/GeoServerStoreRepositoryResolver.java
@@ -18,8 +18,8 @@ public class GeoServerStoreRepositoryResolver implements GeoGigDataStoreFactory.
             //enforce unix file seperators
             String unixsep = FilenameUtils.separatorsToUnix(info.getLocation());
             //check if refers to file, if it does add the file prefix
-            if(FilenameUtils.getPrefix(unixsep)!=null&&!unixsep.startsWith("file:/"))
-            	unixsep = "file:/"+unixsep;
+            if(FilenameUtils.getPrefix(unixsep)!=null&&!unixsep.startsWith("file://"))
+            	unixsep = "file://"+unixsep;
             return URI.create(unixsep);
         } catch (IOException e) {
             throw Throwables.propagate(e);


### PR DESCRIPTION
The Unix "file" URI prefix is missing a "slash". For example, the Unix file path "/tmp/repo" should be represented as a URI like this:

file:**///**tmp/repo

as opposed to

file:**//**tmp/repo
